### PR TITLE
pending configuration in docker-compose

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,6 +18,9 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: <%= ENV["POSTGRES_USER"] %>
+  password: <%= ENV["POSTGRES_PASSWORD"] %>
+  host: db
 
 development:
   <<: *default
@@ -55,7 +58,7 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *defaultp
+  <<: *default
   database: store_test
   url: <%= ENV['DATABASE_URL'] %>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.active_job.query_adapter = :sidekiq
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 :concurrency: 3
 :timeout: 60
-:verbose: true
+:verbose: false
 :queues:
   - critical
   - default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,63 @@
 version: '3'
 
 services:
-    db:
-        image: postgres:16-alpine
-        environment:
-          - POSTGRES_USER=postgres
-          - POSTGRES_PASSWORD=password
-        ports:
-            - '5432:5432'
-        volumes:
-            - postgres13:/var/lib/postgresql/data
-    redis:
-        image: redis:7.0.15-alpine
-        ports:
-        - '6379:6379'
-        volumes:
-        - redis_data:/data  
-    web:
-        ## TODO
-    test:
-        build: .
-        command: bundle exec rspec
-        volumes:
-            - .:/rails
-        depends_on:
-            - db
-            - redis 
-        environment:
-            - DATABASE_URL: postgresql://postgres:password@db:5432/myapp_test
-            - REDIS_URL: redis://redis:6379/0
+  db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres:/var/lib/postgresql/data
+  redis:
+    image: redis:7.0.15-alpine
+    ports:
+      - '6379:6379'
+    volumes:
+      - redis_data:/data
+  worker:
+    build: .
+    command: bundle exec sidekiq
+    env_file:
+      - ./.env
+    volumes:
+      - .:/app
+    depends_on:
+      - redis
+  web:
+    build: .
+    entrypoint: ["bash", "./setup_app.sh"]
+    command: bundle exec rails server -p 3000 -b '0.0.0.0'
+    environment:
+      RAILS_ENV: development
+    env_file:
+      - ./.env
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+      - redis
+    ports:
+      - "3000:3000"
+    profiles:
+      - development
+  test:
+    build: .
+    entrypoint: ["bash", "./setup_app.sh"]
+    command: bundle exec rspec
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+      - redis 
+    environment:
+      RAILS_ENV: test
+    env_file:
+      - ./.env
+    profiles:
+      - test
+
 volumes:
-    postgres13:
+  postgres:
+  redis_data:

--- a/setup_app.sh
+++ b/setup_app.sh
@@ -1,0 +1,29 @@
+set -e
+
+DB_NAME=${POSTGRES_DB:-store_development}
+TEST_DB_NAME=${POSTGRES_TEST_DB:-store_test}
+RAILS_ENV=${RAILS_ENV:-development}
+
+create_db_if_not_exists() {
+  local DB_TO_CHECK=$1
+  local ENV_TO_USE=$2
+
+  if RAILS_ENV=$ENV_TO_USE bundle exec rails db:environment:set >/dev/null 2>&1; then
+    echo "Database ${DB_TO_CHECK} already exists."
+  else
+    echo "Database ${DB_TO_CHECK} not found. Creating..."
+    RAILS_ENV=$ENV_TO_USE bundle exec rails db:create
+  fi
+}
+
+if [ "$RAILS_ENV" == "development" ]; then
+  create_db_if_not_exists "$DB_NAME" development
+  bundle exec rails db:migrate
+elif [ "$RAILS_ENV" == "test" ]; then
+  create_db_if_not_exists "$TEST_DB_NAME" test
+  bundle exec rails db:migrate
+else
+  echo "Environment $RAILS_ENV is not supported in this script."
+fi
+
+exec "$@"


### PR DESCRIPTION
# Problem

:ticket: [Link to the issue](https://github.com/Amystherdam/tech-interview-backend-entry-level-main/issues/1)

Adding pending points to be able to run the application in docker

# Solution

The configurations for the web service container that will run the application, workers with sidekiq, a bash script to create a database when needed when starting the containers and some additional configurations were implemented in docker-compose.

# Testing

## Setup

Set up a file in the project root called .env that will contain the variables used in docker-compose

In your local environment, with Docker installed, run

```
docker-compose build
```

Then, to open the development environment, run

```
docker-compose --profile development up
```

To run only the tests, run

```
docker-compose --profile test up --abort-on-container-exit
```