### PR TITLE
List items current cart

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -3,7 +3,7 @@ class CartsController < ApplicationController
 
   # GET /cart
   def show
-    # TODO
+    render json: CartSerializer.new(@cart).as_json, status: :ok
   end
 
   # POST /cart


### PR DESCRIPTION
# Problem

:ticket: [Link to the issue](https://github.com/Amystherdam/tech-interview-backend-entry-level-main/issues/11)

Bring the items the customer added to the cart in the information payload

# Solution

When the client performs a get on the show endpoint, it should bring the items present in the cart so far

# Testing

## Setup

Ao ser consultado o endpoint get /cart deve apresentar os itens no carrinho, no seguinte formato:

```
{
  "id": 789, // id do carrinho
  "products": [
    {
      "id": 645,
      "name": "Nome do produto",
      "quantity": 2,
      "unit_price": 1.99, // valor unitário do produto
      "total_price": 3.98, // valor total do produto
    },
    {
      "id": 646,
      "name": "Nome do produto 2",
      "quantity": 2,
      "unit_price": 1.99,
      "total_price": 3.98,
    },
  ],
  "total_price": 7.96 // valor total no carrinho
}
```