### PR TITLE
Delete abandoned carts

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -29,7 +29,7 @@ class CartsController < ApplicationController
       return
     end
 
-    cart_item.increment_quantity(by: cart_item_params[:quantity])
+    cart_item.quantity = cart_item_params[:quantity]
 
     if cart_item.save
       render json: CartSerializer.new(@cart).as_json, status: :created

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -29,7 +29,7 @@ class CartsController < ApplicationController
       return
     end
 
-    cart_item.quantity = cart_item_params[:quantity]
+    cart_item.increment_quantity(by: cart_item_params[:quantity])
 
     if cart_item.save
       render json: CartSerializer.new(@cart).as_json, status: :created

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -3,13 +3,13 @@ class Cart < ApplicationRecord
 
   has_many :cart_items, dependent: :destroy
 
-  validates :total_price, numericality: { only_numeric: true, greater_than_or_equal_to: 0 }
+  validates :total_price, numericality: { greater_than_or_equal_to: 0 }
 
   def mark_as_abandoned
     update(status: :abandoned)
   end
 
   def remove_if_abandoned
-    destroy
+    destroy!
   end
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -2,9 +2,23 @@ class CartItem < ApplicationRecord
   belongs_to :cart
   belongs_to :product
 
+  after_commit :update_cart_interaction, :recovery_cart, on: %i[create update destroy]
+
   validates :product_id, uniqueness: { scope: :cart_id, message: "Item is already in cart" }
 
   def increment_quantity(by:)
     self.quantity = (quantity || 0) + by.to_i
   end
+
+  private
+
+    def update_cart_interaction
+      cart.update(last_interaction_at: Time.current)
+    end
+
+    def recovery_cart
+      return if cart.active?
+
+      cart.update(status: :active)
+    end
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -7,6 +7,10 @@ class CartItem < ApplicationRecord
   validates :product_id, uniqueness: { scope: :cart_id, message: "Item is already in cart" }
   validates :quantity, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
 
+  def increment_quantity(by:)
+    self.quantity = (quantity || 0) + by.to_i
+  end
+
   private
 
     def update_cart_interaction

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -5,10 +5,7 @@ class CartItem < ApplicationRecord
   after_commit :update_cart_interaction, :recovery_cart, on: %i[create update destroy]
 
   validates :product_id, uniqueness: { scope: :cart_id, message: "Item is already in cart" }
-
-  def increment_quantity(by:)
-    self.quantity = (quantity || 0) + by.to_i
-  end
+  validates :quantity, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
 
   private
 

--- a/app/sidekiq/mark_cart_as_abandoned_job.rb
+++ b/app/sidekiq/mark_cart_as_abandoned_job.rb
@@ -1,7 +1,23 @@
 class MarkCartAsAbandonedJob
   include Sidekiq::Job
+  queue_as :default
 
-  def perform(*args)
-    # TODO Impletemente um Job para gerenciar, marcar como abandonado. E remover carrinhos sem interação. 
+  def perform
+    mark_as_abandoned
+    remove_abandoned
+  end
+
+  private
+
+  def mark_as_abandoned
+    Cart.active.where("last_interaction_at <= ?", 3.hours.ago).find_each do |cart|
+      cart.mark_as_abandoned
+    end
+  end
+
+  def remove_abandoned
+    Cart.abandoned.where("last_interaction_at <= ?", 7.days.ago).find_each do |cart|
+      cart.remove_if_abandoned
+    end
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,3 +7,8 @@
   - mailers
   - active_storage_analysis
   - active_storage_purge
+:scheduler:
+  :schedule: 
+    mark_cart_as_abandoned:
+      cron: "0 */5 * * * *"
+      class: "MarkCartAsAbandonedJob"

--- a/spec/factories/carts.rb
+++ b/spec/factories/carts.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :shopping_cart, class: Cart do
     total_price { Faker::Commerce.price(range: 0..10_000) }
-    last_interaction_at { DateTime.now }
+    last_interaction_at { Time.current }
+    status { :active }
   end
 end

--- a/spec/sidekiq/mark_cart_as_abandoned_job_spec.rb
+++ b/spec/sidekiq/mark_cart_as_abandoned_job_spec.rb
@@ -1,3 +1,48 @@
 require 'rails_helper'
+require 'sidekiq/testing'
+
 RSpec.describe MarkCartAsAbandonedJob, type: :job do
+  before { Sidekiq::Testing.inline! }
+
+  let!(:active_recent_cart) do
+    create(:shopping_cart, status: :active, last_interaction_at: 1.hour.ago)
+  end
+
+  let!(:active_old_cart) do
+    create(:shopping_cart, status: :active, last_interaction_at: 4.hours.ago)
+  end
+
+  let!(:abandoned_recent_cart) do
+    create(:shopping_cart, status: :abandoned, last_interaction_at: 2.days.ago)
+  end
+
+  let!(:abandoned_old_cart) do
+    create(:shopping_cart, status: :abandoned, last_interaction_at: 8.days.ago)
+  end
+
+  describe "#perform" do
+    it "does not mark recently active carts as abandoned" do
+      expect {
+        described_class.new.perform
+      }.not_to change { active_recent_cart.reload.status }
+    end
+
+    it "Marks active carts with no interaction for more than 3 hours as abandoned" do
+      expect {
+        described_class.new.perform
+      }.to change { active_old_cart.reload.status }.from("active").to("abandoned")
+    end
+
+    it "does not remove carts abandoned less than 7 days ago" do
+      expect {
+        described_class.new.perform
+      }.not_to change { Cart.exists?(abandoned_recent_cart.id) }
+    end
+
+    it "removes carts abandoned for more than 7 days" do
+      expect {
+        described_class.new.perform
+      }.to change { Cart.exists?(abandoned_old_cart.id) }.from(true).to(false)
+    end
+  end
 end


### PR DESCRIPTION
# Problem

:ticket: [Link to the issue](https://github.com/Amystherdam/tech-interview-backend-entry-level-main/issues/15)

Carts can be abandoned for a long time, sessions can end when you exit the browser, and records can accumulate unnecessary space.

# Solution

Deleting abandoned carts consists of checking periodically (I added 5-minute intervals for this) through a sidekiq schedule if there are carts abandoned for more than 3 hours, if they have not been updated again and if they have been abandoned for more than 7 days.

# Testing

## Setup

A job is expected to run every 5 minutes cleaning abandoned carts based on predefined times.